### PR TITLE
Fix typo in Rebol/Ren-C titles; update filenames to current

### DIFF
--- a/rebol/whitespace.reb
+++ b/rebol/whitespace.reb
@@ -1,12 +1,12 @@
 Rebol [
-    Title: "Whitespace Intepreter"
+    Title: "Whitespace Interpreter"
     Purpose: "Whitespace Language Written as a Rebol 3 Parse Dialect"
 
     Author: "Hostile Fork"
     Home: http://github.com/hostilefork/whitespacers/
     License: 'mit
 
-    File: %whitespace.r
+    File: %whitespace.reb
     Date: 10-Jul-2010
     Version: 0.2.0
 

--- a/ren-c/whitespace.reb
+++ b/ren-c/whitespace.reb
@@ -1,12 +1,12 @@
 Rebol [
-    Title: "Whitespace Intepreter"
+    Title: "Whitespace Interpreter"
     Purpose: "Whitespace Language Written as a Rebol 3 Parse Dialect"
 
     Author: "Hostile Fork"
     Home: http://github.com/hostilefork/whitespacers/
     License: 'mit
 
-    File: %whitespace.r
+    File: %whitespace.reb
     Date: 10-Jul-2010
     Version: 0.2.0
 


### PR DESCRIPTION
This small patch fixes a couple of typos in the Rebol and Ren-C interpreters. I noticed these while adding them to my [ws-corpus](https://github.com/wspace-lang/ws-corpus).